### PR TITLE
docs: document test command in AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS Instructions
+
+- To run the unit tests, set the `CHROME_BIN` environment variable and run:
+  `CHROME_BIN=/tmp/chrome-headless-no-sandbox npm test -- --watch=false --browsers=ChromeHeadless`
+- The path `/tmp/chrome-headless-no-sandbox` should be an executable script that launches Google Chrome in headless mode, for example:
+  ```bash
+  #!/usr/bin/env bash
+  /usr/bin/google-chrome --headless --no-sandbox --disable-gpu "$@"
+  ```
+  Save this script to `/tmp/chrome-headless-no-sandbox` and make it executable if it does not already exist.


### PR DESCRIPTION
## Summary
- add AGENTS instructions for running tests via headless Chrome script

## Testing
- `CHROME_BIN=/tmp/chrome-headless-no-sandbox npm test -- --watch=false --browsers=ChromeHeadless`

------
https://chatgpt.com/codex/tasks/task_e_68ab5dc7ddf48324afc3943f73681d4e