### PR TITLE
docs: add formatting and linting instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,14 @@
 - To run the unit tests, set the `CHROME_BIN` environment variable and run:
   `CHROME_BIN=/tmp/chrome-headless-no-sandbox npm test -- --watch=false --browsers=ChromeHeadless`
 - The path `/tmp/chrome-headless-no-sandbox` should be an executable script that launches Google Chrome in headless mode, for example:
+
   ```bash
   #!/usr/bin/env bash
   /usr/bin/google-chrome --headless --no-sandbox --disable-gpu "$@"
   ```
+
   Save this script to `/tmp/chrome-headless-no-sandbox` and make it executable if it does not already exist.
+
+- Before committing changes, format and lint the codebase to ensure consistency:
+  - `npm run format` – runs Prettier to format the repository
+  - `npm run lint` – runs ESLint to check for code quality issues


### PR DESCRIPTION
## Summary
- instruct contributors to run Prettier via `npm run format`
- advise running `npm run lint` before committing

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abe3a465fc8324b258474641a22ef4