### PR TITLE
feat: add light and dark theme toggle

### DIFF
--- a/public/assets/i18n/en-ca.json
+++ b/public/assets/i18n/en-ca.json
@@ -25,5 +25,7 @@
     "title": "Contact Me",
     "email": "Email"
   },
-  "toggleLang": "Français"
+  "toggleLang": "Français",
+  "darkMode": "Dark mode",
+  "lightMode": "Light mode"
 }

--- a/public/assets/i18n/fr-ca.json
+++ b/public/assets/i18n/fr-ca.json
@@ -25,5 +25,7 @@
     "title": "Me contacter",
     "email": "Courriel"
   },
-  "toggleLang": "English"
+  "toggleLang": "English",
+  "darkMode": "Mode sombre",
+  "lightMode": "Mode clair"
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,6 +3,11 @@
   <a href="#projects">{{ 'nav.projects' | transloco }}</a>
   <a href="#contact">{{ 'nav.contact' | transloco }}</a>
   <button (click)="toggleLanguage()">{{ 'toggleLang' | transloco }}</button>
+  <button (click)="toggleTheme()">
+    {{
+      themeService.currentTheme === 'dark' ? ('lightMode' | transloco) : ('darkMode' | transloco)
+    }}
+  </button>
 </nav>
 
 <main>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -3,11 +3,11 @@
   gap: 1rem;
   justify-content: center;
   padding: 1rem;
-  background-color: #f5f5f5;
+  background-color: var(--nav-background-color);
 
   a {
     text-decoration: none;
-    color: #333;
+    color: var(--link-color);
     font-weight: 600;
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslocoModule, TranslocoService } from '@jsverse/transloco';
+import { ThemeService } from './theme.service';
 
 interface Project {
   nameKey: string;
@@ -15,6 +16,7 @@ interface Project {
 })
 export class AppComponent {
   private translocoService = inject(TranslocoService);
+  themeService = inject(ThemeService);
   constructor() {
     document.documentElement.lang = this.translocoService.getActiveLang();
     this.translocoService.langChanges$.subscribe((lang) => {
@@ -38,5 +40,9 @@ export class AppComponent {
   toggleLanguage() {
     const lang = this.translocoService.getActiveLang();
     this.translocoService.setActiveLang(lang === 'en-ca' ? 'fr-ca' : 'en-ca');
+  }
+
+  toggleTheme() {
+    this.themeService.toggleTheme();
   }
 }

--- a/src/app/theme.service.ts
+++ b/src/app/theme.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, Renderer2, RendererFactory2, inject } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  private renderer: Renderer2 = inject(RendererFactory2).createRenderer(null, null);
+  private theme: 'light' | 'dark' =
+    (localStorage.getItem('theme') as 'light' | 'dark' | null) ?? 'light';
+
+  constructor() {
+    this.updateThemeClass();
+  }
+
+  toggleTheme(): void {
+    this.theme = this.theme === 'light' ? 'dark' : 'light';
+    localStorage.setItem('theme', this.theme);
+    this.updateThemeClass();
+  }
+
+  get currentTheme(): 'light' | 'dark' {
+    return this.theme;
+  }
+
+  private updateThemeClass(): void {
+    const htmlElement = document.documentElement;
+    if (this.theme === 'dark') {
+      this.renderer.addClass(htmlElement, 'dark-theme');
+    } else {
+      this.renderer.removeClass(htmlElement, 'dark-theme');
+    }
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,1 +1,24 @@
-/* You can add global styles to this file, and also import other style files */
+/* Global theme variables */
+:root {
+  --background-color: #ffffff;
+  --text-color: #000000;
+  --nav-background-color: #f5f5f5;
+  --link-color: #333333;
+}
+
+.dark-theme {
+  --background-color: #121212;
+  --text-color: #ffffff;
+  --nav-background-color: #1f1f1f;
+  --link-color: #90caf9;
+}
+
+body {
+  background-color: var(--background-color);
+  color: var(--text-color);
+  margin: 0;
+}
+
+a {
+  color: var(--link-color);
+}


### PR DESCRIPTION
## Summary
- add ThemeService to manage light and dark modes
- define global CSS variables for themes and update navigation styles
- add toggle button with translations to switch themes

## Testing
- `npm run format`
- `npm run lint`
- `CHROME_BIN=/tmp/chrome-headless-no-sandbox npm test -- --watch=false --browsers=ChromeHeadless`


------
https://chatgpt.com/codex/tasks/task_e_68abf85b7e9c8324b078aab7c801348e